### PR TITLE
test(client): define validation retry behavior

### DIFF
--- a/packages/client/src/core/should-retry.ts
+++ b/packages/client/src/core/should-retry.ts
@@ -37,5 +37,6 @@ export function shouldRetry({ attempt, method, retry, error }: ShouldRetryParams
     return false;
   }
 
+  // Non-transient errors (e.g. validation failures) are not retried.
   return false;
 }

--- a/packages/client/tests/integration/response-validation.test.ts
+++ b/packages/client/tests/integration/response-validation.test.ts
@@ -92,4 +92,32 @@ describe('response validation', () => {
 
     await expect(client.get('/users/1')).resolves.toEqual({ id: 'user-1' });
   });
+
+  it('does not retry when response validation fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'Roman' }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+
+    const client = createClient({
+      baseUrl: 'https://api.example.com',
+      fetch: fetchMock,
+      retry: {
+        attempts: 3,
+        retryOn: ['network-error', '5xx', '429'],
+        retryMethods: ['GET'],
+      },
+      validateResponse(data) {
+        return typeof data === 'object' && data !== null && 'id' in data;
+      },
+    });
+
+    await expect(client.get('/users/1')).rejects.toBeInstanceOf(ValidationError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/client/tests/unit/should-retry.test.ts
+++ b/packages/client/tests/unit/should-retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { HttpError } from '../../src/errors/http-error';
 import { NetworkError } from '../../src/errors/network-error';
+import { ValidationError } from '../../src/errors/validation-error';
 import { RequestAbortedError } from '../../src/errors/request-aborted-error';
 import { shouldRetry } from '../../src/core/should-retry';
 import type { RetryConfig } from '../../src/types/config';
@@ -21,6 +22,18 @@ function createHttpError(status: number, statusText = 'Error'): HttpError {
   });
 
   return new HttpError(response);
+}
+
+function createValidationError(): ValidationError {
+  const response = new Response(JSON.stringify({ name: 'Roman' }), {
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+
+  return new ValidationError(response, { name: 'Roman' });
 }
 
 function createParams(
@@ -127,6 +140,16 @@ describe('shouldRetry', () => {
       shouldRetry(
         createParams({
           error: new RequestAbortedError(),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not retry validation errors', () => {
+    expect(
+      shouldRetry(
+        createParams({
+          error: createValidationError(),
         }),
       ),
     ).toBe(false);


### PR DESCRIPTION
## Summary

Defines retry behavior for response validation failures.

## Changes

- add unit coverage for `ValidationError` in `shouldRetry`
- add integration coverage to ensure validation failures are not retried
- document the current safety contract through tests

## Behavior

`ValidationError` is not retried by default, even when retry is enabled.

Closes #56