### PR TITLE
feat(client): expose validation result in hooks

### DIFF
--- a/packages/client/src/core/execution-context.ts
+++ b/packages/client/src/core/execution-context.ts
@@ -1,4 +1,5 @@
 import type { HeadersMap } from '../types/common';
+import type { ResponseValidationResult } from '../types/hooks';
 import type { RequestConfig } from '../types/request';
 
 export type ExecutionContext = {
@@ -11,6 +12,7 @@ export type ExecutionContext = {
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
+  validation?: ResponseValidationResult;
 };
 
 type CreateExecutionContextParams = {

--- a/packages/client/src/core/hook-context.ts
+++ b/packages/client/src/core/hook-context.ts
@@ -38,6 +38,7 @@ export function createAfterResponseContext<T>(
     ...createLifecycleContextBase(execution),
     response,
     data,
+    ...(execution.validation !== undefined ? { validation: execution.validation } : {}),
   };
 }
 

--- a/packages/client/src/core/request.ts
+++ b/packages/client/src/core/request.ts
@@ -112,6 +112,11 @@ export async function request<T>(
       if (validateResponse) {
         const validationResult = await validateResponse(data);
 
+        execution.validation = {
+          enabled: true,
+          passed: validationResult !== false,
+        };
+
         if (validationResult === false) {
           throw new ValidationError(response, data);
         }

--- a/packages/client/src/types/hooks.ts
+++ b/packages/client/src/types/hooks.ts
@@ -2,6 +2,11 @@ import type { HeadersMap } from './common';
 import type { RequestConfig } from './request';
 import type { RetryCondition } from './config';
 
+export type ResponseValidationResult = {
+  enabled: boolean;
+  passed: boolean;
+};
+
 type LifecycleContextBase = {
   request: RequestConfig;
   url: URL;
@@ -20,6 +25,7 @@ export type BeforeRequestContext = LifecycleContextBase;
 export type AfterResponseContext<T = unknown> = LifecycleContextBase & {
   response: Response;
   data: T;
+  validation?: ResponseValidationResult;
 };
 
 export type ErrorContext = LifecycleContextBase & {

--- a/packages/client/tests/integration/response-validation.test.ts
+++ b/packages/client/tests/integration/response-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createClient, ValidationError } from '../../src';
+import { getFirstMockCall } from '../testUtils';
 
 describe('response validation', () => {
   it('returns data when client-level validation passes', async () => {
@@ -119,5 +120,68 @@ describe('response validation', () => {
     await expect(client.get('/users/1')).rejects.toBeInstanceOf(ValidationError);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes validation result in afterResponse hook when validation passes', async () => {
+    const afterResponse = vi.fn();
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'user-1' }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+
+    const client = createClient({
+      baseUrl: 'https://api.example.com',
+      fetch: fetchMock,
+      hooks: {
+        afterResponse,
+      },
+      validateResponse(data) {
+        return typeof data === 'object' && data !== null && 'id' in data;
+      },
+    });
+
+    await client.get('/users/1');
+
+    expect(afterResponse).toHaveBeenCalledTimes(1);
+    expect(afterResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        validation: {
+          enabled: true,
+          passed: true,
+        },
+      }),
+    );
+  });
+
+  it('does not expose validation result when validation is not configured', async () => {
+    const afterResponse = vi.fn();
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'user-1' }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+
+    const client = createClient({
+      baseUrl: 'https://api.example.com',
+      fetch: fetchMock,
+      hooks: {
+        afterResponse,
+      },
+    });
+
+    await client.get('/users/1');
+
+    expect(afterResponse).toHaveBeenCalledTimes(1);
+    const ctx = getFirstMockCall(afterResponse);
+    expect(ctx).not.toHaveProperty('validation');
   });
 });


### PR DESCRIPTION
## Summary

Exposes response validation metadata in lifecycle hooks.

## Changes

- add `ResponseValidationResult` type
- store validation result in the execution context
- expose validation metadata in `afterResponse`
- add integration coverage for validation hook metadata

## Behavior

When response validation is configured and passes, `afterResponse` receives:

```ts
validation: {
  enabled: true,
  passed: true
}
```

When validation is not configured, the validation field is omitted.

Closes #57